### PR TITLE
Adding x509 support and a GetIDByLabel function

### DIFF
--- a/slot.go
+++ b/slot.go
@@ -260,9 +260,12 @@ func publicKey(obj obj, c, t string) (crypto.PublicKey, error) {
 			&pkcs11.Attribute{Type: pkcs11.CKA_VALUE},
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading value of certificate from pkcs11: %v", err)
 		}
 		cert, err := x509.ParseCertificate(attrs[0].Value)
+		if err != nil {
+			return nil, fmt.Errorf("parsing x509 certificate from pkcs11 value: %v", err)
+		}
 		return cert.PublicKey, nil
 	}
 	switch t {

--- a/slot.go
+++ b/slot.go
@@ -146,19 +146,22 @@ func (s *Slot) findKey(search []*pkcs11.Attribute) (*Key, error) {
 		return nil, err
 	}
 	var pub, priv pkcs11.ObjectHandle
+	var pubKeyType string
 	if c0 == "public" && c1 == "private" {
 		pub = objs[0]
 		priv = objs[1]
+		pubKeyType = t0
 	} else if c0 == "private" && c1 == "public" {
 		pub = objs[1]
 		priv = objs[0]
+		pubKeyType = t1
 	} else {
 		return nil, fmt.Errorf("pkcs11: got keys of class %s and %s", c0, c1)
 	}
 	if strings.TrimPrefix(t0, "x509:") != strings.TrimPrefix(t1, "x509:") {
 		return nil, fmt.Errorf("pkcs11: got keys of type %s and %s", t0, t1)
 	}
-	pubkey, err := publicKey(obj{s.module.ctx, h, pub}, t0)
+	pubkey, err := publicKey(obj{s.module.ctx, h, pub}, pubKeyType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary

This changeset adds support for public keys x509 certificates stored in PKCS11 and adds a function to get a mapping from a `CKA_LABEL` to a CKA_ID`.
# Motivation

Gnome stores certs as x509 alongside with private keys, and I want to be able to look them up. Private keys are stored with the same ID, but not with the same label, and in order to access an analogous key pair on different machines, being able to look up the key by ID is useful.
# Testing

Works for me on Linux. 🙃
